### PR TITLE
feat(ux): redirect unauthenticated protected routes to /login; update MathCounts CTAs

### DIFF
--- a/docs/migration/MIGRATION_STATUS.md
+++ b/docs/migration/MIGRATION_STATUS.md
@@ -1,12 +1,12 @@
 # Migration Status
 
-**Last Updated**: August 31, 2025  
-**Status**: COMPLETE ✅  
-**Branch**: `feature/consolidation-prisma-lc`
+**Last Updated**: September 3, 2025  
+**Status**: RECOVERY IN PROGRESS ✅  
+**Branch**: `main`
 
 ## Overview
 
-Homer Enrichment Hub has successfully migrated from Firebase to Supabase + Prisma stack. This document tracks the completion status of all migration phases.
+Homer Enrichment Hub has migrated from Firebase to the Supabase + Prisma stack. This document now tracks recovery/orthogonalization work as we fold in changes from historical branches.
 
 ## Migration Phases
 
@@ -38,10 +38,21 @@ Homer Enrichment Hub has successfully migrated from Firebase to Supabase + Prism
 - [x] Type safety preserved
 
 ### ✅ Phase 5: Documentation & Tooling
-- [x] Documentation reorganization
-- [x] Migration guides updated
-- [x] Development setup streamlined
-- [x] CI/CD updated for new stack
+- [x] Documentation reorganization (recovered)
+- [x] Migration guide + completed artifacts (recovered)
+- [x] Development setup streamlined (Bun + Biome)
+- [x] CI/CD updated for new stack (Supabase envs; build stabilized)
+
+## Recovery Slices (completed)
+- Unified auth UX: `/login` renders single auth form; `/signup` redirects
+- Header CTAs: public CTAs route to `/login`
+- Docs: `docs/migration/README.md` index added; guide and artifacts restored
+- Cleanup: removed legacy `*.original` files; generalized auth error utils
+
+## Recovery Slices (up next)
+- Services parity round 2: verify all pages use Prisma services and types
+- UI parity: restore improved admin/dashboard behaviors (announcements, calendar)
+- Tests/CI: stabilize vitest reporters, confirm mocks; prune legacy references
 
 ## Current Stack
 

--- a/src/app/__a11y__/home.a11y.test.tsx
+++ b/src/app/__a11y__/home.a11y.test.tsx
@@ -1,5 +1,5 @@
-vi.mock('@/hooks/use-auth', () => ({
-  useAuth: () => ({ user: null, loading: false }),
+vi.mock('@/hooks/use-supabase-auth', () => ({
+  useSupabaseAuth: () => ({ user: null, loading: false }),
 }));
 
 import axeCore from 'axe-core';

--- a/src/app/programs/mathcounts/page.tsx
+++ b/src/app/programs/mathcounts/page.tsx
@@ -20,7 +20,7 @@ export default function MathCountsPage() {
             </p>
             <div className="mt-6 flex gap-4">
               <Button asChild size="lg">
-                <Link href="/register">Register for 2025 Season</Link>
+                <Link href="/login">Register for 2025 Season</Link>
               </Button>
               <Button variant="outline" size="lg" asChild>
                 <a href="https://www.mathcounts.org/" target="_blank" rel="noopener">
@@ -285,7 +285,7 @@ export default function MathCountsPage() {
                     Registration is open for the 2025 season. Secure your spot today!
                   </p>
                   <Button variant="secondary" className="w-full" asChild>
-                    <Link href="/register">Register Now</Link>
+                    <Link href="/login">Register Now</Link>
                   </Button>
                 </CardContent>
               </Card>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,7 @@ export async function middleware(request: NextRequest) {
   // Redirect to login if accessing protected route without auth
   if (isProtectedRoute && !user) {
     const redirectUrl = request.nextUrl.clone();
-    redirectUrl.pathname = '/';
+    redirectUrl.pathname = '/login';
     redirectUrl.searchParams.set('redirectedFrom', request.nextUrl.pathname);
     return NextResponse.redirect(redirectUrl);
   }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -7,13 +7,32 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-// Mock Next.js navigation and Firebase modules used in tests
+// Mock Next.js navigation and Supabase modules used in tests
 
-// Mock Firebase (to avoid initialization in tests)
-vi.mock('@/lib/firebase-config', () => ({
-  auth: {},
-  db: {},
-  storage: {},
+// Mock Supabase factories (avoid real initialization in tests)
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({ data: { session: null } }),
+      onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+      signInWithPassword: async () => ({ error: null }),
+      signInWithOAuth: async () => ({ error: null }),
+      signInWithOtp: async () => ({ error: null }),
+      signUp: async () => ({ error: null }),
+      signOut: async () => ({}),
+      resetPasswordForEmail: async () => ({ error: null }),
+      exchangeCodeForSession: async () => ({ error: null }),
+      getUser: async () => ({ data: { user: null } }),
+    },
+  }),
+}));
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({ data: { user: null } }),
+      exchangeCodeForSession: async () => ({ error: null }),
+    },
+  }),
 }));
 
 // Mock next/navigation
@@ -30,16 +49,7 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/',
 }));
 
-// Mock firebase modules commonly imported in code
-vi.mock('@/lib/firebase', () => ({ db: {} }));
-vi.mock('firebase/firestore', () => ({
-  collection: vi.fn(() => ({})),
-  doc: vi.fn(() => ({})),
-  setDoc: vi.fn(async () => undefined),
-  updateDoc: vi.fn(async () => undefined),
-  getDoc: vi.fn(async () => ({ exists: () => false, data: () => ({}) })),
-  serverTimestamp: vi.fn(() => new Date()),
-}));
+// Remove legacy Firebase mocks; Supabase is the current stack
 
 // Fail tests on console.error/console.warn to catch regressions
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;


### PR DESCRIPTION
- Middleware now redirects unauthenticated access to protected routes to /login (with redirectedFrom)\n- MathCounts program page CTAs point to /login to align with unified auth flow