### PR TITLE
test(ui): add EventDialog render tests; polyfill ResizeObserver

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -103,3 +103,12 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
     dispatchEvent: () => false,
   });
 }
+
+// Polyfill ResizeObserver for Radix UI components in tests
+if (typeof window !== 'undefined' && !(window as any).ResizeObserver) {
+  (window as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any;
+}


### PR DESCRIPTION
- Adds render tests verifying default and provided start/end time labels in EventDialog\n- Polyfills ResizeObserver in test setup to satisfy Radix UI components