### PR TITLE
feat(ui): sort announcements pinned-first; admin users date format; docs: Recovery Tracker

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { format } from 'date-fns';
 import {
   AlertCircle,
   Calendar,
@@ -312,7 +313,7 @@ export default function UserManagementPage() {
                         <div className="text-muted-foreground flex items-center gap-1 text-sm">
                           <Calendar className="h-3 w-3" />
                           {user.createdAt
-                            ? new Date(user.createdAt).toLocaleDateString()
+                            ? format(new Date(user.createdAt), 'MMM d, yyyy')
                             : 'Unknown'}
                         </div>
                       </TableCell>

--- a/src/app/announcements/page.tsx
+++ b/src/app/announcements/page.tsx
@@ -198,9 +198,18 @@ export default function AnnouncementsPage() {
     );
   }
 
-  const visibleAnnouncements = showPinnedOnly
-    ? announcements.filter((a) => a.pinned)
-    : announcements;
+  const visibleAnnouncements = (
+    showPinnedOnly ? announcements.filter((a) => a.pinned) : announcements
+  )
+    .slice()
+    .sort((a, b) => {
+      // Pinned first, then newest first by publishedAt
+      const pinDelta = Number(b.pinned) - Number(a.pinned);
+      if (pinDelta !== 0) return pinDelta;
+      const aTime = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
+      const bTime = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
+      return bTime - aTime;
+    });
 
   return (
     <div className="container mx-auto max-w-6xl space-y-6 p-6">


### PR DESCRIPTION
- Announcements: sort pinned first, then newest by published date\n- Admin Users: format created date via date-fns\n- Docs: add docs/migration/RECOVERY_TRACKER.md summarizing merged recovery PRs