### PR TITLE
fix(deploy): remove Firebase auth rewrites to enable Supabase auth flow

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,11 +7,5 @@
     "app/api/webhooks/**/*.ts": {
       "maxDuration": 30
     }
-  },
-  "rewrites": [
-    {
-      "source": "/__/auth/:path*",
-      "destination": "https://kbe-website.firebaseapp.com/__/auth/:path*"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Problem
The production site at homerenrichment.com is showing the old auth flow because vercel.json still contains Firebase auth rewrites.

## Solution
- Remove Firebase auth path rewrites from vercel.json
- This enables the improved unified auth flow already in main
- Production will now use Supabase Auth exclusively

## Changes
- Removed the `/__/auth/:path*` rewrite rule pointing to Firebase
- No other changes needed - all auth improvements are already in main

## Impact
Once deployed, production will have:
- Unified login/register at `/login`
- Supabase Auth (email, magic link, Google)
- All routes properly redirecting to the new auth flow
- Better UI/UX with the unified auth form